### PR TITLE
Data loading Fixes (combined train & test dataset + updated sampler to take in larger dataset)

### DIFF
--- a/data/linear_preprocessing.py
+++ b/data/linear_preprocessing.py
@@ -47,25 +47,26 @@ def get_image_data(config: Dict) -> ConcatDataset:
     else:
         subset_indices = []
 
+    both_datasets = []
     try:
         if config["data_config"]["dataset"].casefold() == "mnist":
             for x in [True, False]:
-                tv_dataset = tv.datasets.MNIST(root=config["data_config"]["data_kwargs"]["root"],
+                both_datasets.append(tv.datasets.MNIST(root=config["data_config"]["data_kwargs"]["root"],
                                                download=config["data_config"]["data_kwargs"]["download"],
                                                train=x,
-                                               transform=transform)
+                                               transform=transform))
         elif config["data_config"]["dataset"].casefold() == "cifar10":
             for x in [True, False]:
-                tv_dataset = tv.datasets.CIFAR10(root=config["data_config"]["data_kwargs"]["root"],
+                both_datasets.append(tv.datasets.CIFAR10(root=config["data_config"]["data_kwargs"]["root"],
                                                  download=config["data_config"]["data_kwargs"]["download"],
                                                  train=x,
-                                                 transform=transform)
+                                                 transform=transform))
         elif config["data_config"]["dataset"].casefold() == "imagenet":
             for x in ["train", "val"]:
-                tv_dataset = tv.datasets.ImageNet(root=config["data_config"]["data_kwargs"]["root"],
+                both_datasets.append(tv.datasets.ImageNet(root=config["data_config"]["data_kwargs"]["root"],
                                                   download=config["data_config"]["data_kwargs"]["download"],
                                                   train=x,
-                                                  transform=transform)
+                                                  transform=transform))
         else:
             raise NotImplementedError(f"{config['data_config']['dataset']} is not a dataset")
     except Exception as e:
@@ -73,12 +74,13 @@ def get_image_data(config: Dict) -> ConcatDataset:
 
     to_concat = []
     to_concat_targets = []
-    if isinstance(subset, int):
-        to_concat.append(Subset(tv_dataset, subset_indices))
-        to_concat_targets.append(tv_dataset.targets[:subset])
-    else:
-        to_concat.append(tv_dataset)
-        to_concat_targets.append(tv_dataset.targets)
+    for tv_dataset in both_datasets:
+        if isinstance(subset, int):
+            to_concat.append(Subset(tv_dataset, subset_indices))
+            to_concat_targets.append(tv_dataset.targets[:subset])
+        else:
+            to_concat.append(tv_dataset)
+            to_concat_targets.append(tv_dataset.targets)
 
     # In case targets are not a tensor (like in CIFAR10)
     to_concat_targets = [torch.tensor(x) for x in to_concat_targets]

--- a/main.py
+++ b/main.py
@@ -129,7 +129,10 @@ def main():
         if (param_data is not None) and (len(datasets) < len(param_data)): #if there's not enough MNIST data partition based on number of parameters
             dataloaders = QuineSplit(config, datasets, param_data, device).partition()
     elif config["data_config"]["dataset"].casefold() == "cifar10":
-        dataloaders = MNISTSplit(config, datasets, param_data, device).partition()  # MNIST split appears to work fine with CIFAR
+        if len(datasets) < len(param_data):
+            dataloaders = MNISTSplit(config, datasets, param_data, "param_data", device).partition()  # MNIST split appears to work fine with CIFAR
+        else:
+            dataloaders = MNISTSplit(config, datasets, param_data, "aux_data", device).partition()
     else:
         raise NotImplementedError(f"{config['data_config']['dataset']} is not a valid split")
     logger.info(f"Successfully split dataset and parameters")

--- a/utils/holdout.py
+++ b/utils/holdout.py
@@ -61,7 +61,8 @@ class AbstractSplit(ABC):
 
     def get_dataloaders(self, samplers: List[torch.utils.data.Sampler]) -> List:
         if self.config["model_aug_config"]["model_augmentation"] == "auxiliary":
-            return [DataLoader(CombineDataset(self.dataset, self.param_data),
+            combined_dataset = CombineDataset(self.dataset, self.param_data)
+            return [DataLoader(combined_dataset,
                                       batch_size=1,
                                       sampler=sampler) for sampler in samplers]
         elif self.config["model_aug_config"]["model_augmentation"] == "vanilla":

--- a/utils/holdout.py
+++ b/utils/holdout.py
@@ -85,12 +85,13 @@ class AbstractSplit(ABC):
 
 
 class MNISTSplit(AbstractSplit):
-    def __init__(self, config, dataset, param_data, device):
+    def __init__(self, config, dataset, param_data, larger_dataset, device):
         super(MNISTSplit, self).__init__(config, dataset, param_data, device)
         self.config = config
         self.data_config = config["data_config"]
         self.dataset = dataset
         self.param_data = param_data  # Needed for Aux models
+        self.larger_dataset = larger_dataset
         self.device = device
 
     def holdout(self) -> Dict[str, DataLoader]:
@@ -103,7 +104,11 @@ class MNISTSplit(AbstractSplit):
             logger.info(f"Could not find split size in config, splitting dataset into {DEFAULT_SPLIT}")
 
         # train_x, test_x, train_y, test_y = train_test_split(self.dataset, self.dataset.targets, train_size=split_size, random_state=self.config["seed"])
-        split_idx = list(ShuffleSplit(n_splits=1, train_size=split_size, random_state=self.config["seed"]).split(self.dataset, self.dataset.targets))
+        split_idx = None
+        if self.larger_dataset == "aux_data":
+            split_idx = list(ShuffleSplit(n_splits=1, train_size=split_size, random_state=self.config["seed"]).split(self.dataset, self.dataset.targets))
+        elif self.larger_dataset == "param_data":
+            split_idx = list(ShuffleSplit(n_splits=1, train_size=split_size, random_state=self.config["seed"]).split(self.param_data.params))
         samplers = [torch.utils.data.SubsetRandomSampler(idx_array) for idx_array in split_idx[0]]
         dataloaders = self.get_dataloaders(samplers)
 


### PR DESCRIPTION
- Previously, only test dataset was used leading to a much smaller full dataset that was then split 70-30
- Previously, the sampler for MNIST would only take the length of the dataset and split it. But it runs into problem for regeneration later on with the number of params is > length of dataset.